### PR TITLE
Add WebAssembly support to Spring Boot application

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,56 @@
+# Spring Boot CRUD Application with WebAssembly
+
+This project demonstrates how to integrate WebAssembly with a Spring Boot CRUD application.
+
+## Prerequisites
+
+- Java 21 or higher
+- Maven 3.6.3 or higher
+
+## Building the Project
+
+1. Clone the repository:
+   ```sh
+   git clone https://github.com/zlovtnik/apps.git
+   cd apps
+   ```
+
+2. Build the project using Maven:
+   ```sh
+   ./mvnw clean install
+   ```
+
+## Running the Application
+
+1. Run the Spring Boot application:
+   ```sh
+   ./mvnw spring-boot:run
+   ```
+
+2. The application will start and load the WebAssembly file `sample.wasm` located in `src/main/webassembly`.
+
+## WebAssembly Integration
+
+The WebAssembly file `sample.wasm` is loaded and executed in the `AppApplication` class. The result of the WebAssembly function is printed to the console.
+
+## Sample WebAssembly File
+
+The sample WebAssembly file `sample.wasm` contains a simple function that adds two integers. The function is defined as follows:
+
+```wasm
+(module
+  (type $t0 (func (param i32 i32) (result i32)))
+  (func $sampleFunction (export "sampleFunction") (type $t0) (param $p0 i32) (param $p1 i32) (result i32)
+    local.get $p0
+    local.get $p1
+    i32.add)
+  (memory $memory (export "memory") 1)
+  (global $g0 (mut i32) (i32.const 0))
+  (global $g1 i32 (i32.const 0))
+  (table $table (export "table") 1 funcref)
+  (elem (i32.const 0) $sampleFunction))
+```
+
+## Additional Information
+
+For more information on WebAssembly and its integration with Java, refer to the [Wasmer Java documentation](https://github.com/wasmerio/wasmer-java).

--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,12 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<!-- P0c7e -->
+		<dependency>
+			<groupId>org.wasmer</groupId>
+			<artifactId>wasmer-java</artifactId>
+			<version>0.3.0</version>
+		</dependency>
 	</dependencies>
 
 	<build>
@@ -58,6 +64,32 @@
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
+			</plugin>
+			<!-- Pd2e1 -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-resources-plugin</artifactId>
+				<version>3.2.0</version>
+				<executions>
+					<execution>
+						<id>copy-resources</id>
+						<phase>validate</phase>
+						<goals>
+							<goal>copy-resources</goal>
+						</goals>
+						<configuration>
+							<outputDirectory>${project.build.directory}/webassembly</outputDirectory>
+							<resources>
+								<resource>
+									<directory>src/main/webassembly</directory>
+									<includes>
+										<include>**/*.wasm</include>
+									</includes>
+								</resource>
+							</resources>
+						</configuration>
+					</execution>
+				</executions>
 			</plugin>
 		</plugins>
 	</build>

--- a/src/main/java/us/rcs/app/app/AppApplication.java
+++ b/src/main/java/us/rcs/app/app/AppApplication.java
@@ -2,12 +2,32 @@ package us.rcs.app.app;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.wasmer.Instance;
+import org.wasmer.Module;
+import org.wasmer.Store;
+import org.wasmer.exports.Function;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 
 @SpringBootApplication
 public class AppApplication {
 
 	public static void main(String[] args) {
 		SpringApplication.run(AppApplication.class, args);
+
+		try {
+			byte[] wasmBytes = Files.readAllBytes(Paths.get("src/main/webassembly/sample.wasm"));
+			Store store = new Store();
+			Module module = new Module(store, wasmBytes);
+			Instance instance = new Instance(module);
+			Function function = instance.exports.getFunction("sampleFunction");
+			int result = function.call(5, 3);
+			System.out.println("Result from WebAssembly: " + result);
+		} catch (IOException e) {
+			e.printStackTrace();
+		}
 	}
 
 }

--- a/src/main/webassembly/sample.wasm
+++ b/src/main/webassembly/sample.wasm
@@ -1,0 +1,11 @@
+(module
+  (type $t0 (func (param i32 i32) (result i32)))
+  (func $sampleFunction (export "sampleFunction") (type $t0) (param $p0 i32) (param $p1 i32) (result i32)
+    local.get $p0
+    local.get $p1
+    i32.add)
+  (memory $memory (export "memory") 1)
+  (global $g0 (mut i32) (i32.const 0))
+  (global $g1 i32 (i32.const 0))
+  (table $table (export "table") 1 funcref)
+  (elem (i32.const 0) $sampleFunction))


### PR DESCRIPTION
Fixes #1

Add WebAssembly integration to the Spring Boot application.

* **Dependencies and Plugins**:
  - Add WebAssembly dependency to `pom.xml`.
  - Add Maven resources plugin to handle WebAssembly files in `pom.xml`.

* **Main Application**:
  - Import WebAssembly classes in `AppApplication.java`.
  - Add code to load and execute the WebAssembly file in the `main` method of `AppApplication.java`.

* **WebAssembly File**:
  - Add a sample WebAssembly file `sample.wasm` in `src/main/webassembly`.

* **Documentation**:
  - Add `README.md` to explain how to build and run the Spring Boot application with WebAssembly.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/zlovtnik/apps/pull/2?shareId=37d928c6-c4db-45db-bcef-224f047820dc).